### PR TITLE
fix: Resolve rendering issue in quickstart package manager instructions

### DIFF
--- a/docs/quick--start/quickstart.md
+++ b/docs/quick--start/quickstart.md
@@ -65,23 +65,35 @@ and more.
 
 To install the EAS contracts, run the following command within your project directory
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+```mdx-code-block
 <Tabs>
   <TabItem value="yarn" label="yarn" default>
-    ```bash
-    yarn add @ethereum-attestation-service/eas-sdk
 ```
+
+```bash
+yarn add @ethereum-attestation-service/eas-sdk
+```
+```mdx-code-block
   </TabItem>
   <TabItem value="npm" label="npm">
-    ```bash
+```
+```bash
 npm install @ethereum-attestation-service/eas-sdk
 ```
+```mdx-code-block
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
-    ```bash 
+```
+```bash 
 pnpm add @ethereum-attestation-service/eas-sdk
 ```
+```mdx-code-block
   </TabItem>
 </Tabs>
+```
 
 📖 Read More: [The SDK Docs](/docs/developer-tools.md/eas-sdk.md)
 


### PR DESCRIPTION

Resolves rendering issues by importing [MDX Tabs ](https://docusaurus.io/docs/next/markdown-features/tabs) and by structuring the formatting so that the code blocks could display inside the tabs.

Example of how Docusaurus does it in their own documentation: https://github.com/facebook/docusaurus/blob/main/website/docs/guides/markdown-features/markdown-features-code-blocks.mdx#L296

Before:
<img width="689" alt="image" src="https://github.com/ethereum-attestation-service/eas-docs-site/assets/2483304/99a6ec51-03fa-4796-ac40-8be6303f2781">

After:
<img width="624" alt="image" src="https://github.com/ethereum-attestation-service/eas-docs-site/assets/2483304/2c9d9017-4190-4c2b-bf3d-367588020c01">

