### PR TITLE
Small typos and link fixes

### DIFF
--- a/docs/core--concepts/attestations.md
+++ b/docs/core--concepts/attestations.md
@@ -63,15 +63,15 @@ Creating an attestation is a straightforward process, but it's underpinned by ro
 
 4. **Verification:** Post creation, anyone can verify the attestation if made available to them. They can check the digital signature against the issuer's public key, ensuring the attestation's authenticity.
 
-5. **Lifecycle Management:** Over time, the status of an attestation might change. While it can't be edited due it is immutability, it can be revoked if the information is no longer valid. This revocation is also stored, ensuring a clear history of the attestation's lifecycle.
+5. **Lifecycle Management:** Over time, the status of an attestation might change. While it can't be edited due to its immutability, it can be revoked if the information is no longer valid. This revocation is also stored, ensuring a clear history of the attestation's lifecycle.
 
 6. **Referencing & Building:** One of EAS's powerful features is the ability to reference other attestations. This allows for the creation of a web of interconnected attestations, each adding context and depth to the others.
 
 ## Tools to Start Building
 To dive deeper into the world of attestations and begin crafting your own, explore the EAS platform. We offer a range of tools and resources, from a no-code schema builder to SDKs, that make the process intuitive and efficient. Join the EAS community and be a part of the movement in digital trust and verification.
 
-- [**SDK**](/docs/developer-tools.md/eas-sdk.md)
-- [**GraphQL API**](/docs/developer-tools.md/api.md)
+- [**SDK**](/docs/developer-tools/eas-sdk.md)
+- [**GraphQL API**](/docs/developer-tools/api.md)
 - [**Tutorials**](/docs/category/tutorials)
 
 

--- a/docs/core--concepts/how-eas-works.md
+++ b/docs/core--concepts/how-eas-works.md
@@ -31,7 +31,7 @@ struct SchemaRecord {
     string schema; // Custom specification of the schema (e.g., an ABI).
 }
 ```
-Before you rush to create a new schema, it's worth checking the schemas already registered on the [Explorer](./category/the-explorer). The community often contributes schemas, making it a rich resource. If you find one that fits your needs, great! If not, you can design a new one.
+Before you rush to create a new schema, it's worth checking the schemas already registered on the [Explorer](https://easscan.org/schemas). The community often contributes schemas, making it a rich resource. If you find one that fits your needs, great! If not, you can design a new one.
 
 🎓 **Tutorial**: [**Make a Schema**](/docs/tutorials/create-a-schema.md)
 

--- a/docs/core--concepts/onchain-vs-offchain.md
+++ b/docs/core--concepts/onchain-vs-offchain.md
@@ -42,7 +42,7 @@ Attestations can be made either onchain or offchain. While **onchain attestation
 - **Timestamp Offchain Onchain:** Timestamp the UID of the offchain attestation onchain to give it a verifiable proof of existence.
 
 ## Privacy Considerations
-It's important for builder's to consider what data needs to go onchain or should live offchain. A common misconception with onchain attestations is that they do not have privacy features. There are several ways to keep onchain attestation data more private. 
+It's important for builders to consider what data needs to go onchain or should live offchain. A common misconception with onchain attestations is that they do not have privacy features. There are several ways to keep onchain attestation data more private. 
 
 - **Offchain:** Generally preferable for confidentiality as no data is publicly visible unless explicitly stored in places like IPFS.
 - **Private Data Attestations:** An innovative solution to attest nearly an infinite amount of private data by attesting its [merkle root onchain](/docs/tutorials/private-data-attestations.md).

--- a/docs/tutorials/private-data-attestations.md
+++ b/docs/tutorials/private-data-attestations.md
@@ -8,7 +8,7 @@ Discover the power of "Private Data Attestations" using `Merkle Trees`. This is 
 ### What are private data attestations?
 Private Data Attestations leverage Merkle Trees' unique capabilities to selectively disclose specific data fields without compromising overall privacy. This innovative feature allows users to create attestations with a single "private data" field, which contains the hash of a Merkle tree root. As a result, **users can securely store and share particular parts of their attested data** while preserving their privacy.
 
-Attestors can now selectively disclose parts of their attestations without revealing the entire attestation data. This allows for greater control over the information being shared, while still providing the necessary proof or verification for specific use cases. It is beneficial for use cases that require sensitive information to be withheld while still verifying crucial aspects or data.
+Attestors can now selectively disclose parts of their attestations without revealing the entire attestation data. This allows for greater control over the information being shared, while still providing the necessary proof or verification for specific use cases. It is beneficial for use cases that require sensitive information to be withheld while still verifying crucial aspects of data.
 
 **A quick example of how it works:**
 1. The user or entity **submits data for selective disclosure** on the privateData schema.


### PR DESCRIPTION
Fixed a couple of broken links and typos. 

Also the link "Use Cases Page" on `use-cases-overview` is broken but I couldn't see an obvious choice.