### PR TITLE
Replace Base & OP Goerli with Base & OP Sepolia in GraphQL Docs

### DIFF
--- a/docs/developer-tools/api.md
+++ b/docs/developer-tools/api.md
@@ -11,7 +11,7 @@ Welcome to the Easscan GraphQL API documentation! This API allows you to access 
 | Ethereum (Sepolia) | [https://sepolia.easscan.org/graphql](https://sepolia.easscan.org/graphql)                                |
 | Arbitrum | [https://arbitrum.easscan.org/graphql](https://arbitrum.easscan.org/graphql)                                        |
 | Base | [https://base.easscan.org/graphql](https://base.easscan.org/graphql)                                                    |
-| Base (Goerli) | [https://base-goerli.easscan.org/graphql](https://base-goerli.easscan.org/graphql)                             |
+| Base (Sepolia) | [https://base-sepolia.easscan.org/graphql](https://base-sepolia.easscan.org/graphql)                             |
 | Linea | [https://linea.easscan.org/graphql](https://linea.easscan.org/graphql)                                                 |
 | Optimism | [https://optimism.easscan.org/graphql](https://optimism.easscan.org/graphql)                                        |
 | Optimism (Goerli) | [https://optimism-goerli-bedrock.easscan.org/graphql](https://optimism-goerli-bedrock.easscan.org/graphql) |

--- a/docs/developer-tools/api.md
+++ b/docs/developer-tools/api.md
@@ -14,7 +14,7 @@ Welcome to the Easscan GraphQL API documentation! This API allows you to access 
 | Base (Sepolia) | [https://base-sepolia.easscan.org/graphql](https://base-sepolia.easscan.org/graphql)                             |
 | Linea | [https://linea.easscan.org/graphql](https://linea.easscan.org/graphql)                                                 |
 | Optimism | [https://optimism.easscan.org/graphql](https://optimism.easscan.org/graphql)                                        |
-| Optimism (Goerli) | [https://optimism-goerli-bedrock.easscan.org/graphql](https://optimism-goerli-bedrock.easscan.org/graphql) |
+| Optimism (Sepolia) | [https://optimism-sepolia-bedrock.easscan.org/graphql](https://optimism-sepolia-bedrock.easscan.org/graphql) |
 
 ## Introduction
 


### PR DESCRIPTION
Base goerli is deprecated and the current links are broken unless goerli is replaced with sepolia