### PR TITLE
Remove deprecated Goerli Testnets, Add Sepolia Links

### DIFF
--- a/docs/easscan/overview.md
+++ b/docs/easscan/overview.md
@@ -27,9 +27,7 @@ While we aim for the best DevEx, the easscan.org site is not intended to be an e
 |                | Linea          | [https://linea.easscan.org](https://linea.easscan.org)   |
 | **Testnets**   | Sepolia             | [https://sepolia.easscan.org](https://sepolia.easscan.org)     |
 |                | Optimism Sepolia     | [https://optimism-sepolia.easscan.org/](https://optimism-sepolia.easscan.org)   |
-|                | Optimism Goerli     | [https://optimism-goerli.easscan.org/](https://optimism-goerli.easscan.org)   |
 |                | Base Sepolia         | [https://base-sepolia.easscan.org](https://base-sepolia.easscan.org) |
-|                | Base Goerli         | [https://base-goerli.easscan.org](https://base-goerli.easscan.org) |
 |                | Polygon Mumbai         | [https://polygon-mumbai.easscan.org/](https://polygon-mumbai.easscan.org/) |
 |                | Scroll Sepolia         | [https://scroll-sepolia.easscan.org/](https://scroll-sepolia.easscan.org/) |
 

--- a/docs/quick--start/contracts.md
+++ b/docs/quick--start/contracts.md
@@ -9,7 +9,7 @@ Please note that you can also import and use the addresses directly in your code
 ## 🛳️ Deployments
 :::tip We have deployed on the following chains:
 - **Mainnets**: Ethereum Mainnet, Optimism, Base, Arbitrum One, Arbitrum Nova, Linea, Polygon, Scroll
-- **Testnets**: Sepolia, Optimism Sepolia, Optimism Goerli, Base Sepolia, Base Goerli, Polygon Mumbai, Linea Goerli, Scroll Sepolia
+- **Testnets**: Sepolia, Optimism Sepolia, Base Sepolia, Polygon Mumbai, Scroll Sepolia
 :::
 
 ## Mainnets
@@ -233,30 +233,6 @@ Version `v1.3.0`:
 
 
 
-### Optimism Goerli
-Version `v1.0.1`:
-
-:::info EAS
-- **Contract Address:** [0x4200000000000000000000000000000000000021](https://goerli-optimism.etherscan.io/address/0x4200000000000000000000000000000000000021)
-- **Deployment and ABI:** [EAS.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/optimism-goerli/EAS.json)
-:::
-
-:::info SchemaRegistry
-- **Contract Address:** [0x4200000000000000000000000000000000000020](https://goerli-optimism.etherscan.io/address/0x4200000000000000000000000000000000000020)
-- **Deployment and ABI:** [SchemaRegistry.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/optimism-goerli/SchemaRegistry.json)
-:::
-
-Version `v1.2.0`:
-
-:::info EIP712Proxy
-- **Contract Address:** [0x88D1bd62AC014424b987CE5ABf311BD7749e426B](https://goerli-optimism.etherscan.io/address/0x88D1bd62AC014424b987CE5ABf311BD7749e426B)
-- **Deployment and ABI:** [EIP712Proxy.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/optimism-goerli/EIP712Proxy.json)
-:::
-
-:::info Indexer
-- **Contract Address:** [0xa42428D1bf904d762adD02b27ADac26d53643782](https://goerli-optimism.etherscan.io/address/0xa42428D1bf904d762adD02b27ADac26d53643782)
-- **Deployment and ABI:** [Indexer.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/optimism-goerli/Indexer.json)
-:::
 
 ### Base Sepolia
 Version `v1.2.0`:
@@ -284,45 +260,6 @@ Version `v1.3.0`:
 :::
 
 
-### Base Goerli
-Version `v1.0.1`:
-
-:::info EAS
-- **Contract Address:** [0x4200000000000000000000000000000000000021](https://goerli.basescan.org/address/0x4200000000000000000000000000000000000021)
-- **Deployment and ABI:** [EAS.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/base-goerli/EAS.json)
-:::
-
-:::info SchemaRegistry
-- **Contract Address:** [0x4200000000000000000000000000000000000020](https://goerli.basescan.org/address/0x4200000000000000000000000000000000000020)
-- **Deployment and ABI:** [SchemaRegistry.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/base-goerli/SchemaRegistry.json)
-:::
-
-Version `v1.2.0`:
-
-:::info EIP712Proxy
-- **Contract Address:** [0x37AC6006646f2e687B7fB379F549Dc7634dF5b84](https://goerli.basescan.org/address/0x37AC6006646f2e687B7fB379F549Dc7634dF5b84)
-- **Deployment and ABI:** [EIP712Proxy.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/base-goerli/EIP712Proxy.json)
-:::
-
-:::info Indexer
-- **Contract Address:** [0xE0893F47009776D6aEC3De8455Cb0ed325Eea74a](https://goerli.basescan.org/address/0xE0893F47009776D6aEC3De8455Cb0ed325Eea74a)
-- **Deployment and ABI:** [Indexer.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/base-goerli/Indexer.json)
-:::
-
-
-### Arbitrum Goerli
-Version `v1.1.0`:
-
-:::info EAS
-- **Contract Address:** [0xaEF4103A04090071165F78D45D83A0C0782c2B2a](https://github.com/goerli.arbiscan.io/address/0xaEF4103A04090071165F78D45D83A0C0782c2B2a)
-- **Deployment and ABI:** [EAS.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/arbitrum-goerli/EAS.json)
-:::
-
-:::info SchemaRegistry
-- **Contract Address:** [0x55D26f9ae0203EF95494AE4C170eD35f4Cf77797](https://github.com/goerli.arbiscan.io/address/0x55D26f9ae0203EF95494AE4C170eD35f4Cf77797)
-- **Deployment and ABI:** [SchemaRegistry.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/arbitrum-goerli/SchemaRegistry.json)
-:::
-
 ### Polygon Mumbai
 Version `v1.1.0`:
 
@@ -334,19 +271,6 @@ Version `v1.1.0`:
 :::info SchemaRegistry
 - **Contract Address:** [0x55D26f9ae0203EF95494AE4C170eD35f4Cf77797](https://mumbai.polygonscan.com/address/0x55D26f9ae0203EF95494AE4C170eD35f4Cf77797)
 - **Deployment and ABI:** [SchemaRegistry.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/polygon-mumbai/SchemaRegistry.json)
-:::
-
-### Linea Goerli
-Version `v1.2.0`:
-
-:::info EAS
-- **Contract Address:** [0xaEF4103A04090071165F78D45D83A0C0782c2B2a](https://goerli.lineascan.build/address/0xaEF4103A04090071165F78D45D83A0C0782c2B2a)
-- **Deployment and ABI:** [EAS.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/linea-goerli/EAS.json)
-:::
-
-:::info SchemaRegistry
-- **Contract Address:** [0x55D26f9ae0203EF95494AE4C170eD35f4Cf77797](https://goerli.lineascan.build/address/0x55D26f9ae0203EF95494AE4C170eD35f4Cf77797)
-- **Deployment and ABI:** [SchemaRegistry.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/linea-goerli/SchemaRegistry.json)
 :::
 
 
@@ -371,27 +295,6 @@ Version `v1.3.0`:
 :::info Indexer
 - **Contract:** [0x7C2cb1eDC328491da52de2a0afc44D3B0Ae7ee17](https://sepolia.scrollscan.com/address/0x7C2cb1eDC328491da52de2a0afc44D3B0Ae7ee17)
 - **Deployment and ABI:** [Indexer.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/scroll-sepolia/EIP712Proxy.json)
-:::
-
-
-
-
-
-
-
-
-
-### Linea Goerli
-Version `v1.2.0`:
-
-:::info EAS
-- **Contract Address:** [0xaEF4103A04090071165F78D45D83A0C0782c2B2a](https://goerli.lineascan.build/address/0xaEF4103A04090071165F78D45D83A0C0782c2B2a)
-- **Deployment and ABI:** [EAS.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/linea-goerli/EAS.json)
-:::
-
-:::info SchemaRegistry
-- **Contract Address:** [0x55D26f9ae0203EF95494AE4C170eD35f4Cf77797](https://goerli.lineascan.build/address/0x55D26f9ae0203EF95494AE4C170eD35f4Cf77797)
-- **Deployment and ABI:** [SchemaRegistry.json](https://github.com/ethereum-attestation-service/eas-contracts/blob/master/deployments/linea-goerli/SchemaRegistry.json)
 :::
 
 ## Installation

--- a/docs/quick--start/quickstart.md
+++ b/docs/quick--start/quickstart.md
@@ -116,8 +116,9 @@ Navigate the world of attestations with our dedicated explorer. It's like Ethers
 
 **Testnets**
 - [https://sepolia.easscan.org](https://sepolia.easscan.org)
-- [https://optimism-goerli.easscan.org](https://optimism-goerli.easscan.org)
-- [https://base-goerli.easscan.org](https://base-goerli.easscan.org)
+- [https://optimism-sepolia.easscan.org/](https://optimism-sepolia.easscan.org/)
+- [https://base-sepolia.easscan.org/](https://base-sepolia.easscan.org/)
+- [https://scroll-sepolia.easscan.org/](https://scroll-sepolia.easscan.org/)
 
 **Mainnet**
 - [https://easscan.org/](https://easscan.org/)
@@ -125,6 +126,9 @@ Navigate the world of attestations with our dedicated explorer. It's like Ethers
 **Layer 2's**
 - [https://arbitrum.easscan.org/](https://arbitrum.easscan.org/)
 - [https://optimism.easscan.org/](https://optimism.easscan.org/)
+- [https://base.easscan.org/](https://base.easscan.org/)
+- [https://base.easscan.org/](https://base.easscan.org/)
+- [https://scroll.easscan.org/](https://scroll.easscan.org/)
 
 ![Explorer Example](./img/explorer-example.png)
 

--- a/docs/tutorials/create-a-schema.md
+++ b/docs/tutorials/create-a-schema.md
@@ -40,8 +40,9 @@ EAS uses Ethereum smart contracts to register and verify attestations. Each sche
 | **Base**         | [View Schemas](https://base.easscan.org/schemas)          |
 | **Arbitrum**     | [View Schemas](https://arbitrum.easscan.org/schemas)      |
 | **Sepolia**      | [View Schemas](https://sepolia.easscan.org/schemas)       |
-| **Optimism Goerli** | [View Schemas](https://optimism-goerli.easscan.org/schemas) |
-| **Base Goerli**  | [View Schemas](https://base-goerli.easscan.org/schemas)   |
+| **Optimism Sepolia** | [View Schemas](https://optimism-sepolia.easscan.org/schemas) |
+| **Base Sepolia**  | [View Schemas](https://base-sepolia.easscan.org/schemas)   |
+| **Scroll Sepolia**  | [View Schemas](https://scroll-sepolia.easscan.org/schemas)   |
 
 
 ## Understanding the EAS schema record

--- a/docs/tutorials/get-an-attestation.md
+++ b/docs/tutorials/get-an-attestation.md
@@ -17,8 +17,9 @@ EAS offers a GraphQL API that allows developers to query data in a flexible and 
 | Optimism | [https://optimism.easscan.org/graphql](https://optimism.easscan.org/graphql)                |
 | Linea | [https://linea.easscan.org/graphql](https://linea.easscan.org/graphql)                |
 | Sepolia | [https://sepolia.easscan.org/graphql](https://sepolia.easscan.org/graphql)                         |
-| Optimism-Goerli | [https://optimism-goerli-bedrock.easscan.org/graphql](https://optimism-goerli-bedrock.easscan.org/graphql) |
-| Base-Goerli | [https://base-goerli.easscan.org/graphql](https://base-goerli.easscan.org/graphql)                 |
+| Optimism-Sepolia | [https://optimism-sepolia.easscan.org/graphql](https://optimism-sepolia.easscan.org/graphql) |
+| Base-Sepolia | [https://base-sepolia.easscan.org/graphql](https://base-sepolia.easscan.org/graphql)                 |
+| Scroll-Sepolia | [https://scroll-sepolia.easscan.org/graphql](https://scroll-sepolia.easscan.org/graphql)                 |
 
 
 **Read More:** [**EAS GraphQL API**](#)


### PR DESCRIPTION
Improve Documentation by removing links to old deprecated Goerli Testnetworks (e.g. Optimism/Base Goerli) and adding the respective Sepolia Networks where needed. Also added Scroll Sepolia.