### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ethereum Attestation Sevice Docs
+# Ethereum Attestation Service Docs
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 


### PR DESCRIPTION
"Ethereum Attestation Sevice Docs" — it should be "Ethereum Attestation Service Docs", as the word "Sevice" is incorrect and should be "**Service**".

Corrected.