### PR TITLE
fix: remove duplicate base eascan link

### DIFF
--- a/docs/quick--start/quickstart.md
+++ b/docs/quick--start/quickstart.md
@@ -127,7 +127,6 @@ Navigate the world of attestations with our dedicated explorer. It's like Ethers
 - [https://arbitrum.easscan.org/](https://arbitrum.easscan.org/)
 - [https://optimism.easscan.org/](https://optimism.easscan.org/)
 - [https://base.easscan.org/](https://base.easscan.org/)
-- [https://base.easscan.org/](https://base.easscan.org/)
 - [https://scroll.easscan.org/](https://scroll.easscan.org/)
 
 ![Explorer Example](./img/explorer-example.png)


### PR DESCRIPTION
This commit removes the duplicate base eascan link on quickstart page.