### PR TITLE
Fix formatting of 'Run the script' block in Onchain Attestation in quickstart.md.

### DIFF
--- a/docs/zk--playbook/quickstart.md
+++ b/docs/zk--playbook/quickstart.md
@@ -86,7 +86,7 @@ cargo run --release -- --mode plonk --prove
 Use the included script to verify your JSON proof inside Node.js (browser-compatible).
 
 ```bash
-cd example/WASM_verifier
+cd examples/WASM_verifier
 pnpm install
 pnpm run test
 ```
@@ -104,7 +104,7 @@ CONTRACT_ADDRESS=The contract address
 2. Run the script:
 
 ```bash
-cd example/solidity-verifier
+cd examples/solidity-verifier
 cargo run --release
 Output: Transaction receipt confirming your proof was verified and attested onchain.
 ```

--- a/docs/zk--playbook/quickstart.md
+++ b/docs/zk--playbook/quickstart.md
@@ -76,7 +76,7 @@ wasm-pack build --target nodejs --dev
 Run the age-checking program in SP1 to produce two ZK proofs.
 
 ```bash
-cd example/dob-script
+cd examples/dob/dob-script
 cargo run --release -- --mode groth16 --prove
 cargo run --release -- --mode plonk --prove
 ```

--- a/docs/zk--playbook/quickstart.md
+++ b/docs/zk--playbook/quickstart.md
@@ -103,13 +103,11 @@ CONTRACT_ADDRESS=The contract address
 ```
 2. Run the script:
 
-bash
-Copy
-Edit
+```bash
 cd example/solidity-verifier
 cargo run --release
 Output: Transaction receipt confirming your proof was verified and attested onchain.
-
+```
 
 ## How This Works (Under the Hood)
 Key components of the toolkit:


### PR DESCRIPTION
- Removed unnecessary lines and formatted the run the script block. (Number 2)

<img width="742" height="409" alt="Screenshot 2025-11-10 at 18 08 40" src="https://github.com/user-attachments/assets/bd559a63-9b09-421b-beac-f483022f70a6" />

- Corrected the directory path in the "2. Generate Your Proofs" section from `cd example/dob-script` to `cd examples/dob/dob-script` to reflect the accurate project structure for running the age-checking program and generating ZK proofs with groth16 and plonk modes.

- Closes #47 